### PR TITLE
Removed defer

### DIFF
--- a/dl.go
+++ b/dl.go
@@ -102,12 +102,12 @@ func get(source string) error {
 	for i := 0; i < *concurrency; i++ {
 		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			for off := range offsets {
 				if err := getChunk(out, source, off, size, counts); err != nil {
 					errc <- err
 				}
 			}
+			wg.Done()
 		}()
 	}
 	go func() {


### PR DESCRIPTION
Feel free to close this if you don't like the change. I think it very lightly increases performance based on a discussion from [here](https://github.com/gorilla/context/pull/12). I think defer is better suited on a function with multiple exits or coupled on an open / close situation. I love this example. I'll try and take a closer look later and maybe help with some more potential improvements if that's welcome!
